### PR TITLE
Clean images older than a day

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: image run release
+
+image:
+	docker build --tag codeclimate/builder-gc .
+
+run:
+	docker run \
+	  --rm \
+	  --interactive \
+	  --tty \
+	  --volume /var/run/docker.sock:/var/run/docker.sock \
+	  codeclimate/builder-gc gc_builders
+
+release:
+	docker push codeclimate/builder-gc

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # builder-gc
 
-This Docker image is used to clean up Code Climate build containers after 1
-week. It uses a crontab internally. The containers here are Code Climate
-specific, but this can be used as a proof of concept for cleaning up other types
-of containers.
+This Docker image is used to clean up Code Climate build containers after 1 day.
+It uses a crontab internally. The containers here are Code Climate specific, but
+this can be used as a proof of concept for cleaning up other types of
+containers.
 
 ## License
 

--- a/files/bin/gc_builders
+++ b/files/bin/gc_builders
@@ -5,5 +5,5 @@ printf "Removing containers %s\n" "$(date)"
 for filter in "name=builder-init-*" "name=builder-cloner-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
   printf "Removing containers with %s\n" "$filter"
   docker ps -a -f "$filter" | awk '/day|week|month/ { print $1 }' \
-    | xargs --no-run-if-empty docker rm
+    | xargs --max-args 500 --max-procs 0 --no-run-if-empty docker rm
 done

--- a/files/bin/gc_builders
+++ b/files/bin/gc_builders
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-echo "Removing containers $(date)"
+printf "Removing containers %s\n" "$(date)"
 
 for filter in "name=builder-init-*" "name=builder-cloner-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
+  printf "Removing containers with %s\n" "$filter"
   docker ps -a -f "$filter" | awk '/(7|8|9|1[0-9]) days|week|month/ { print $1 }' | xargs --no-run-if-empty docker rm
 done

--- a/files/bin/gc_builders
+++ b/files/bin/gc_builders
@@ -4,5 +4,6 @@ printf "Removing containers %s\n" "$(date)"
 
 for filter in "name=builder-init-*" "name=builder-cloner-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
   printf "Removing containers with %s\n" "$filter"
-  docker ps -a -f "$filter" | awk '/(7|8|9|1[0-9]) days|week|month/ { print $1 }' | xargs --no-run-if-empty docker rm
+  docker ps -a -f "$filter" | awk '/(7|8|9|1[0-9]) days|week|month/ { print $1 }' \
+    | xargs --no-run-if-empty docker rm
 done

--- a/files/bin/gc_builders
+++ b/files/bin/gc_builders
@@ -4,6 +4,6 @@ printf "Removing containers %s\n" "$(date)"
 
 for filter in "name=builder-init-*" "name=builder-cloner-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
   printf "Removing containers with %s\n" "$filter"
-  docker ps -a -f "$filter" | awk '/(7|8|9|1[0-9]) days|week|month/ { print $1 }' \
+  docker ps -a -f "$filter" | awk '/day|week|month/ { print $1 }' \
     | xargs --no-run-if-empty docker rm
 done


### PR DESCRIPTION
Instead of 1 week. This is to avoid space issues for high-volume customers, and
because we haven't yet actually needed these containers at all.

/cc @codeclimate/review

There are a few changes here, but I tried to make small commits.
