### PR TITLE
Prefix all output with timestamps

### DIFF
--- a/files/bin/gc_builders
+++ b/files/bin/gc_builders
@@ -1,9 +1,18 @@
 #!/bin/sh
+timestamp() {
+  local line
 
-printf "Removing containers %s\n" "$(date)"
+  while read -r line; do
+    printf "[%s] %s\n" "$(date)" "$line"
+  done
+}
 
-for filter in "name=builder-init-*" "name=builder-cloner-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
-  printf "Removing containers with %s\n" "$filter"
-  docker ps -a -f "$filter" | awk '/day|week|month/ { print $1 }' \
-    | xargs --max-args 500 --max-procs 0 --no-run-if-empty docker rm
-done
+{
+  echo "Removing containers"
+
+  for filter in "name=builder-init-*" "name=builder-cloner-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
+    printf "Removing containers with %s\n" "$filter"
+    docker ps -a -f "$filter" | awk '/day|week|month/ { print $1 }' \
+      | xargs --max-args 500 --max-procs 0 --no-run-if-empty docker rm
+  done
+} | timestamp


### PR DESCRIPTION
/cc @codeclimate/review

Appending `?w=1` should make this diff more readable.

I verified locally with `make image && make run`
