### PR TITLE
Ensure builder-gc removes all exited builders

### DIFF
--- a/files/bin/gc_builders
+++ b/files/bin/gc_builders
@@ -10,9 +10,9 @@ timestamp() {
 {
   echo "Removing containers"
 
-  for filter in "name=builder-init-*" "name=builder-cloner-*" "name=builder-pull-engines-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
+  for filter in "name=builder-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
     printf "Removing containers with %s\n" "$filter"
-    docker ps -a -f "$filter" | awk '/day|week|month/ { print $1 }' \
+    docker ps --all --filter "$filter" --filter "status=exited"| awk '/day|week|month/ { print $1 }' \
       | xargs --max-args 500 --max-procs 0 --no-run-if-empty docker rm
   done
 } | timestamp


### PR DESCRIPTION
As part of investigating a customer escalation, Will and I noticed that builder-gc is not cleaning all of the containers it should. 