### PR TITLE
Switch base image to alpine, move boot into a bin script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:14.04
-
-RUN apt-get update && apt-get install -y wget
+FROM alpine:latest
 
 RUN wget -O /bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.6.0
 RUN chmod +x /bin/docker
@@ -12,4 +10,4 @@ COPY files /
 RUN crontab /tmp/crontab
 RUN rm /tmp/crontab
 
-CMD ["/bin/sh", "-c", "cron && tail --retry --follow=name /data/builder-gc/builder_gc.log"]
+CMD ["/bin/start_and_log"]

--- a/files/bin/gc_builders
+++ b/files/bin/gc_builders
@@ -13,6 +13,6 @@ timestamp() {
   for filter in "name=builder-*" "label=com.codeclimate.role=builder" "name=cc-engines-*"; do
     printf "Removing containers with %s\n" "$filter"
     docker ps --all --filter "$filter" --filter "status=exited" | awk '/day|week|month/ { print $1 }' \
-      | xargs --max-args 500 --max-procs 0 --no-run-if-empty docker rm
+      | xargs -t -n 500 -r docker rm
   done
 } | timestamp

--- a/files/bin/start_and_log
+++ b/files/bin/start_and_log
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+crond
+tail -F /data/builder-gc/builder_gc.log


### PR DESCRIPTION
We've been running into some very strange issues with cron not
triggering properly under the Ubuntu base image. I had an image in a
reliable state where it would come and never execute anything until you
ran `crontab -e` or `-l` to "touch" the cron system in some way.
Investigating changing how we loaded the crontab was triggered by a
customer issue with unreliable builder-gc. In my testing the alpine
image has worked exactly as expected and not flaky at all, and it also
cuts down the image size by a couple hundred MB, so I think this is
worthile, although it does mean we need to lean on less-readable flags
for `xargs` and `tail`.